### PR TITLE
added config copy only icons

### DIFF
--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -15,6 +15,10 @@ return [
             // 'height' => 50,
         ],
 
+        'icons' => [
+            //
+        ]
+
     ],
 
     'regular' => [
@@ -30,6 +34,10 @@ return [
             // 'height' => 50,
         ],
 
+        'icons' => [
+            //
+        ]
+
     ],
 
     'solid' => [
@@ -44,6 +52,10 @@ return [
             // 'width' => 50,
             // 'height' => 50,
         ],
+
+        'icons' => [
+            //
+        ]
 
     ],
 
@@ -72,6 +84,10 @@ return [
             // 'height' => 50,
         ],
 
+        'icons' => [
+            //
+        ]
+
     ],
 
     'light' => [
@@ -86,6 +102,10 @@ return [
             // 'width' => 50,
             // 'height' => 50,
         ],
+
+        'icons' => [
+            //
+        ]
 
     ],
 
@@ -102,6 +122,9 @@ return [
             // 'height' => 50,
         ],
 
+        'icons' => [
+            //
+        ]
     ],
 
     'sharp-light' => [
@@ -116,6 +139,10 @@ return [
             // 'width' => 50,
             // 'height' => 50,
         ],
+
+        'icons' => [
+            //
+        ]
 
     ],
 
@@ -132,6 +159,10 @@ return [
             // 'height' => 50,
         ],
 
+        'icons' => [
+            //
+        ]
+
     ],
 
     'sharp-solid' => [
@@ -146,6 +177,10 @@ return [
             // 'width' => 50,
             // 'height' => 50,
         ],
+
+        'icons' => [
+            //
+        ]
 
     ],
 


### PR DESCRIPTION
## Summary 

* **Change 1: More Flexibility in Our Configurations** 🛠️🔧
Ever noticed how sometimes options are greyed out and you can't choose anything? Well, that is about to change. We added an empty `'icons'` array to multiple sections of our `config/blade-fontawesome.php`. This simple change gives us more flexibility in managing app settings and adapting to your needs. Now we can easily include any icons we need! 🚀

* **Change 2: Upgrades to the 'Synchronization of Icons' feature** 🔄💼
Our fantastic crew is continually looking to optimize your experience. In that pursuit, we've upgraded `SyncIconsCommand.php` file:
   - We now have an extra `'--only'` option at your disposal. What does that mean? When syncing icons, you can now specify which ones you want, helping prevent unnecessary clutter and save time. Efficiency at its best! 🎯😃
   - We made sure our app is stronger and smarter by adding some solid error recognition. If a hiccup happens, the app will recognize it and flash a warning message your way. Say goodbye to unexpected errors sneaking up on you. 🕵️‍♀️🔦

We hope you'll enjoy these upgrades as much as we do! Let's continue to work together towards an even better experience. 👏💪🤗

Why don't programmers like to go outside?

Because they're afraid of the sun (`'--only'`) option! 😄

In the realm of `blade-fontawesome` stands a PR,  
A witness to changes both near and far.  
Empty 'icons' arrays, now part of the grand configuration,  
Modifications in `SyncIconsCommand`, a quiet innovation.  

The '--only' option now in command's signature song,  
Only specified icons copied, reducing potential wrong.  
Exception handling and warnings, a subtle saving grace,   
Ever enhancing the code, in this digital embrace.  